### PR TITLE
Allow native paste to respond to url-into-selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
 # Paste URL into selection
 
-Insert links (URLs) into a selected text "notion-style" (default hotkey is `ctrl + shift + v`).
+Insert links (URLs) into a selected text "notion-style" using regular `Ctrl/Cmd + V`
 
-Also works the other way around, inserts text into a selected link (URL).
-
-**NOTE:** Default hotkey might conflict with built-in shortcuts in your OS. 
-If that happens, you can change the plugin hotkey in `Settings` > `Hotkeys` > `Paste URL into selection`.
+Also works the other way around, inserts text into a selected link (URL) by command palette/hotkey(need to be set manually)
 
 ## Demo
 ![example](https://user-images.githubusercontent.com/4748206/98997874-ed55fb80-253d-11eb-9121-709a316a4d1e.gif)

--- a/main.ts
+++ b/main.ts
@@ -33,6 +33,25 @@ export default class UrlIntoSelection extends Plugin {
         },
       ],
     });
+
+    this.registerCodeMirror((cm: CodeMirror.Editor) => {
+      cm.on("paste", (cm, e) => {
+        const clipboardText = e.clipboardData?.getData("text");
+        const selectedText = cm.getSelection();
+        if (selectedText && clipboardText) {
+
+          if (this.isUrl(clipboardText)) {
+            // disable default copy behavior
+            e.preventDefault();
+            cm.replaceSelection(`[${selectedText}](${clipboardText})`);
+          } else if (this.isUrl(selectedText)) {
+            // disable default copy behavior
+            e.preventDefault();
+            cm.replaceSelection(`[${clipboardText}](${selectedText})`);
+          }
+        }
+      });
+    });
   }
 
   urlIntoSelection(): void {

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { Plugin, PluginSettingTab, Setting } from "obsidian";
+import { MarkdownView, Plugin, PluginSettingTab, Setting } from "obsidian";
 import { clipboard } from "electron";
 import * as CodeMirror from "codemirror";
 
@@ -25,13 +25,7 @@ export default class UrlIntoSelection extends Plugin {
     this.addCommand({
       id: "paste-url-into-selection",
       name: "",
-      callback: () => this.urlIntoSelection(),
-      hotkeys: [
-        {
-          modifiers: ["Mod", "Shift"],
-          key: "v",
-        },
-      ],
+      callback: () => this.urlIntoSelection()
     });
 
     this.registerCodeMirror((cm: CodeMirror.Editor) => {
@@ -79,8 +73,11 @@ export default class UrlIntoSelection extends Plugin {
   }
 
   private getEditor(): CodeMirror.Editor {
-    let activeLeaf: any = this.app.workspace.activeLeaf;
-    return activeLeaf.view.sourceMode.cmEditor;
+    let activeLeaf = this.app.workspace.activeLeaf;
+    if (activeLeaf.view instanceof MarkdownView){
+      return activeLeaf.view.sourceMode.cmEditor;
+    }
+    else throw new Error("activeLeaf.view not MarkdownView")
   }
 
   private static getSelectedText(editor: CodeMirror.Editor): string {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@rollup/plugin-commonjs": "^15.1.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
     "@rollup/plugin-typescript": "^6.0.0",
+    "@types/electron": "^1.6.10",
     "@types/node": "^14.14.2",
     "obsidian": "https://github.com/obsidianmd/obsidian-api/tarball/master",
     "prettier": "2.1.2",
@@ -22,9 +23,5 @@
     "standard-version": "^9.0.0",
     "tslib": "^2.0.3",
     "typescript": "^4.0.3"
-  },
-  "dependencies": {
-    "electron": "^10.1.5",
-    "supports-color": "^7.2.0"
   }
 }


### PR DESCRIPTION
now regular `Ctrl/Cmd + V` also support copying url into selection