### PR TITLE
[small] Escape closing parentheses and multiple angle brackets

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -140,8 +140,12 @@ function processUrl(src: string): string {
     output = src;
   }
 
-  if (/[<>]/.test(output))
-    output = output.replace("<", "%3C").replace(">", "%3E");
+  output = output
+      .replace(/</g, "%3C")
+      .replace(/>/g, "%3E")
+      // Markdown uses brackets to enclose URLs. Escape them.
+      .replace(/\(/g, "%28")
+      .replace(/\)/g, "%29");
 
   return /[\(\) ]/.test(output) ? `<${output}>` : output;
 }


### PR DESCRIPTION
Changes:
- escape parentheses so that the URL doesn't get truncated (and gets displayed correctly in reading view) when it contains parentheses.
- escape all angle brackets in the url (it used to only escape the first occurrence).

One can try pasting an URL such as `https://something.com?foo=(())<<>>123` for testing before/after this change.