### PR TITLE
Only Paste URLs

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -37,6 +37,9 @@ export default function UrlIntoSelection(editor: Editor, cb: string | ClipboardE
   const replaceText = getReplaceText(clipboardText, selectedText, settings);
   if (replaceText === null) return;
 
+  // If onlyUrls is enabled, and the text is not a URL, do nothing
+  if (settings.onlyUrls && !isUrl(clipboardText, settings)) return;
+
   // apply changes
   if (typeof cb !== "string") cb.preventDefault(); // prevent default paste behavior
   replace(editor, replaceText, replaceRange);

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -16,6 +16,7 @@ export interface PluginSettings {
   regex: string;
   nothingSelected: NothingSelected;
   listForImgEmbed: string;
+  onlyUrls: boolean;
 }
 
 export const DEFAULT_SETTINGS: PluginSettings = {
@@ -23,6 +24,7 @@ export const DEFAULT_SETTINGS: PluginSettings = {
     .source,
   nothingSelected: NothingSelected.doNothing,
   listForImgEmbed: "",
+  onlyUrls: true,
 };
 
 export class UrlIntoSelectionSettingsTab extends PluginSettingTab {
@@ -32,6 +34,19 @@ export class UrlIntoSelectionSettingsTab extends PluginSettingTab {
 
     containerEl.empty();
     containerEl.createEl("h2", { text: "URL-into-selection Settings" });
+
+    new Setting(containerEl)
+      .setName("Only URLs")
+      .setDesc(
+        "Only turns the selected text into a URL when the clipboard text is a URL"
+      )
+      .addToggle((toggle) => {
+        toggle.setValue(plugin.settings.onlyUrls).onChange((value) => {
+          plugin.settings.onlyUrls = value;
+          plugin.saveData(plugin.settings);
+          return value;
+        });
+      });
 
     new Setting(containerEl)
       .setName("Fallback Regular expression")


### PR DESCRIPTION
This PR adds a setting that allows users to enable this plugin only when the clipboard text is a URL. This prevents a variety of pasting issues when the selected text is not a URL, and the user only wants to replace the selected text with the contents of the clipboard.