### PR TITLE
feat: add Smart Label mode for per-domain URL label extraction

### DIFF
--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { Editor } from "./test/obsidian-mock";
 import UrlIntoSelection from "./core";
-import { NothingSelected, PluginSettings } from "./types";
+import { NothingSelected, PluginSettings, SmartLabelRule, SmartLabelDefault } from "./types";
 import { DEFAULT_SETTINGS } from "./test/test-settings";
 
 // Expose internal functions for testing by importing them differently
@@ -781,6 +781,136 @@ describe("Obsidian Wikilink Support", () => {
       UrlIntoSelection(editor, clipboardText, settings);
       expect(editor.getValue()).toBe("[[10. Links#Header1|Click Link Here]]");
     });
+  });
+});
+
+describe("Smart Label mode", () => {
+  let editor: Editor;
+
+  function makeSettings(rules: SmartLabelRule[] = [], defaultBehavior: SmartLabelDefault = { prefix: "", behavior: "insertinline" }) {
+    return {
+      ...DEFAULT_SETTINGS,
+      nothingSelected: NothingSelected.smartLabel,
+      smartLabelRules: rules,
+      smartLabelDefault: defaultBehavior,
+    };
+  }
+
+  beforeEach(() => {
+    editor = new Editor("", { line: 0, ch: 0 });
+  });
+
+  it("rule matched, asis → [AA-123](url)", () => {
+    const settings = makeSettings([
+      { pattern: "jira.company.com", prefix: "", behavior: "asis" },
+    ]);
+    UrlIntoSelection(editor, "https://jira.company.com/browse/AA-123", settings);
+    expect(editor.getValue()).toBe("[AA-123](https://jira.company.com/browse/AA-123)");
+  });
+
+  it("rule matched, titlecase + slug → [My Cool Feature](url)", () => {
+    const settings = makeSettings([
+      { pattern: "linear.app", prefix: "", behavior: "titlecase" },
+    ]);
+    UrlIntoSelection(editor, "https://linear.app/team/my-cool-feature", settings);
+    expect(editor.getValue()).toBe("[My Cool Feature](https://linear.app/team/my-cool-feature)");
+  });
+
+  it("rule matched, titlecase + ID-like → ID preserved", () => {
+    const settings = makeSettings([
+      { pattern: "jira.company.com", prefix: "", behavior: "titlecase" },
+    ]);
+    UrlIntoSelection(editor, "https://jira.company.com/browse/AA-123", settings);
+    expect(editor.getValue()).toBe("[AA-123](https://jira.company.com/browse/AA-123)");
+  });
+
+  it("rule matched, uppercase → segment uppercased", () => {
+    const settings = makeSettings([
+      { pattern: "example.com", prefix: "", behavior: "uppercase" },
+    ]);
+    UrlIntoSelection(editor, "https://example.com/page/my-feature", settings);
+    expect(editor.getValue()).toBe("[MY-FEATURE](https://example.com/page/my-feature)");
+  });
+
+  it("rule matched, prefixonly with prefix 'Blog' → [Blog](url), segment ignored", () => {
+    const settings = makeSettings([
+      { pattern: "blog.company.com", prefix: "Blog", behavior: "prefixonly" },
+    ]);
+    UrlIntoSelection(editor, "https://blog.company.com/some-long-post-title", settings);
+    expect(editor.getValue()).toBe("[Blog](https://blog.company.com/some-long-post-title)");
+  });
+
+  it("rule matched, donothing → no change to editor", () => {
+    const settings = makeSettings([
+      { pattern: "example.com", prefix: "", behavior: "donothing" },
+    ]);
+    UrlIntoSelection(editor, "https://example.com/page", settings);
+    expect(editor.getValue()).toBe("");
+  });
+
+  it("rule matched, insertinline → [](url), cursor between brackets", () => {
+    const settings = makeSettings([
+      { pattern: "example.com", prefix: "", behavior: "insertinline" },
+    ]);
+    UrlIntoSelection(editor, "https://example.com/page", settings);
+    expect(editor.getValue()).toBe("[](https://example.com/page)");
+    expect(editor.getCursor()).toEqual({ line: 0, ch: 1 });
+  });
+
+  it("rule matched, insertbare → <url>", () => {
+    const settings = makeSettings([
+      { pattern: "example.com", prefix: "", behavior: "insertbare" },
+    ]);
+    UrlIntoSelection(editor, "https://example.com/page", settings);
+    expect(editor.getValue()).toBe("<https://example.com/page>");
+  });
+
+  it("rule matched, autoselect → [word](url)", () => {
+    editor = new Editor("word here", { line: 0, ch: 2 });
+    const settings = makeSettings([
+      { pattern: "example.com", prefix: "", behavior: "autoselect" },
+    ]);
+    UrlIntoSelection(editor, "https://example.com/page", settings);
+    expect(editor.getValue()).toBe("[word](https://example.com/page) here");
+  });
+
+  it("no rule matches → uses default behavior", () => {
+    const settings = makeSettings(
+      [{ pattern: "other.com", prefix: "", behavior: "asis" }],
+      { prefix: "", behavior: "insertbare" },
+    );
+    UrlIntoSelection(editor, "https://example.com/page", settings);
+    expect(editor.getValue()).toBe("<https://example.com/page>");
+  });
+
+  it("default insertinline with no match → [](url), cursor between brackets", () => {
+    const settings = makeSettings([], { prefix: "", behavior: "insertinline" });
+    UrlIntoSelection(editor, "https://example.com/page", settings);
+    expect(editor.getValue()).toBe("[](https://example.com/page)");
+    expect(editor.getCursor()).toEqual({ line: 0, ch: 1 });
+  });
+
+  it("URL with no path segment → [](url), cursor between brackets", () => {
+    const settings = makeSettings([], { prefix: "", behavior: "asis" });
+    UrlIntoSelection(editor, "https://example.com", settings);
+    expect(editor.getValue()).toBe("[](https://example.com)");
+    expect(editor.getCursor()).toEqual({ line: 0, ch: 1 });
+  });
+
+  it("pattern with * wildcard → matches correctly", () => {
+    const settings = makeSettings([
+      { pattern: "*.company.com", prefix: "Co: ", behavior: "asis" },
+    ]);
+    UrlIntoSelection(editor, "https://jira.company.com/browse/AA-123", settings);
+    expect(editor.getValue()).toBe("[Co: AA-123](https://jira.company.com/browse/AA-123)");
+  });
+
+  it("asis with prefix → prefix prepended to segment", () => {
+    const settings = makeSettings([
+      { pattern: "jira.company.com", prefix: "Jira: ", behavior: "asis" },
+    ]);
+    UrlIntoSelection(editor, "https://jira.company.com/browse/AA-123", settings);
+    expect(editor.getValue()).toBe("[Jira: AA-123](https://jira.company.com/browse/AA-123)");
   });
 });
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,9 +1,10 @@
 import assertNever from "assert-never";
 import { NothingSelected, PluginSettings } from "./types";
 import { Editor, EditorPosition, EditorRange } from "obsidian";
-import { isUrl, processUrl, isImgEmbed, isWikilink } from "./utils/url";
+import { isUrl, processUrl, isImgEmbed, isWikilink, isAlreadyWrapped } from "./utils/url";
 import { checkIfInMarkdownLink } from "./utils/markdown";
 import { stripSurroundingQuotes } from "./utils/quotes";
+import { findMatchingRule, buildSmartLabel, isExtractionBehavior } from "./utils/smartLabel";
 
 /**
  * @param editor Obsidian Editor Instance
@@ -42,6 +43,12 @@ export default function UrlIntoSelection(
     return;
   }
 
+  // Smart Label has its own self-contained path
+  if (!editor.somethingSelected() && settings.nothingSelected === NothingSelected.smartLabel) {
+    handleSmartLabel(editor, cb, settings);
+    return;
+  }
+
   const clipboardText = getCbText(cb);
   if (clipboardText === null) return;
 
@@ -75,6 +82,65 @@ export default function UrlIntoSelection(
   }
 }
 
+function handleSmartLabel(
+  editor: Editor,
+  cb: string | ClipboardEvent,
+  settings: PluginSettings,
+): void {
+  const clipboardText = getCbText(cb);
+  if (!clipboardText) return;
+  if (!isUrl(clipboardText, settings)) return;
+
+  const url = processUrl(clipboardText);
+  const matchedRule = findMatchingRule(url, settings.smartLabelRules);
+  const rule = matchedRule ?? settings.smartLabelDefault;
+
+  // donothing: don't intercept the paste at all
+  if (rule.behavior === "donothing") return;
+
+  if (typeof cb !== "string") cb.preventDefault();
+
+  switch (rule.behavior) {
+    case "autoselect": {
+      const replaceRange = getWordBoundaries(editor, settings);
+      const selectedText = editor.getRange(replaceRange.from, replaceRange.to);
+      const replaceText = `[${selectedText}](${url})`;
+      replace(editor, replaceText, replaceRange);
+      editor.setCursor({ ch: replaceRange.from.ch + replaceText.length, line: replaceRange.from.line });
+      break;
+    }
+
+    case "insertbare": {
+      const replaceRange = getCursor(editor);
+      const bareUrl = isAlreadyWrapped(url) ? url : `<${url}>`;
+      replace(editor, bareUrl, replaceRange);
+      editor.setCursor({ ch: replaceRange.from.ch + bareUrl.length, line: replaceRange.from.line });
+      break;
+    }
+
+    case "insertinline": {
+      const replaceRange = getCursor(editor);
+      replace(editor, `[](${url})`, replaceRange);
+      editor.setCursor({ ch: replaceRange.from.ch + 1, line: replaceRange.from.line });
+      break;
+    }
+
+    default: {
+      // Label extraction behaviors: asis, titlecase, uppercase, lowercase, prefixonly
+      const replaceRange = getCursor(editor);
+      const label = buildSmartLabel(url, rule);
+      const replaceText = `[${label}](${url})`;
+      replace(editor, replaceText, replaceRange);
+      if (!label) {
+        editor.setCursor({ ch: replaceRange.from.ch + 1, line: replaceRange.from.line });
+      } else {
+        editor.setCursor({ ch: replaceRange.from.ch + replaceText.length, line: replaceRange.from.line });
+      }
+      break;
+    }
+  }
+}
+
 function getSelnRange(editor: Editor, settings: PluginSettings) {
   let selectedText: string;
   let replaceRange: EditorRange | null;
@@ -95,6 +161,8 @@ function getSelnRange(editor: Editor, settings: PluginSettings) {
         break;
       case NothingSelected.doNothing:
         throw new Error("should be skipped");
+      case NothingSelected.smartLabel:
+        throw new Error("smartLabel nothing-selected path should be handled before getSelnRange");
       default:
         assertNever(settings.nothingSelected);
     }
@@ -271,4 +339,5 @@ export {
   findWordAt,
   getCursor,
   replace,
+  handleSmartLabel,
 };

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -1,6 +1,7 @@
 import UrlIntoSel_Plugin from "./main";
 import { PluginSettingTab, Setting } from "obsidian";
-import { NothingSelected, PluginSettings } from "./types";
+import { NothingSelected, PluginSettings, SmartLabelBehavior, SmartLabelDefault, SmartLabelRule } from "./types";
+import { isExtractionBehavior, isValidPattern } from "./utils/smartLabel";
 
 export { NothingSelected, PluginSettings } from "./types";
 
@@ -10,7 +11,119 @@ export const DEFAULT_SETTINGS: PluginSettings = {
       .source,
   nothingSelected: NothingSelected.doNothing,
   listForImgEmbed: "",
+  smartLabelRules: [],
+  smartLabelDefault: { prefix: "", behavior: "asis" },
 };
+
+function buildBehaviorSelect(
+  container: HTMLElement,
+  current: SmartLabelBehavior,
+  onChange: (v: SmartLabelBehavior) => void,
+): HTMLSelectElement {
+  const select = container.createEl("select", { cls: "dropdown" });
+
+  const g1 = select.createEl("optgroup");
+  g1.label = "Segment transform";
+  for (const [value, label] of [
+    ["asis", "As is"],
+    ["titlecase", "Title Case"],
+    ["uppercase", "UPPERCASE"],
+    ["lowercase", "lowercase"],
+    ["prefixonly", "Prefix Only"],
+  ] as [SmartLabelBehavior, string][]) {
+    const opt = g1.createEl("option", { text: label });
+    opt.value = value;
+    if (value === current) opt.selected = true;
+  }
+
+  const g2 = select.createEl("optgroup");
+  g2.label = "Paste behavior";
+  for (const [value, label] of [
+    ["donothing", "Do nothing"],
+    ["autoselect", "Auto Select"],
+    ["insertinline", "Insert [](url)"],
+    ["insertbare", "Insert <url>"],
+  ] as [SmartLabelBehavior, string][]) {
+    const opt = g2.createEl("option", { text: label });
+    opt.value = value;
+    if (value === current) opt.selected = true;
+  }
+
+  select.addEventListener("change", () => {
+    onChange(select.value as SmartLabelBehavior);
+  });
+  return select;
+}
+
+function renderRuleRow(
+  container: HTMLElement,
+  rule: SmartLabelRule,
+  onDelete: () => void,
+  onSave: () => void,
+): void {
+  const row = container.createDiv({ cls: "smart-label-rule-row" });
+  if (!isValidPattern(rule.pattern)) row.addClass("smart-label-row-invalid");
+
+  const patternInput = row.createEl("input", { type: "text", cls: "smart-label-input" });
+  patternInput.placeholder = "e.g. jira.company.com";
+  patternInput.value = rule.pattern;
+  patternInput.addEventListener("input", () => {
+    if (isValidPattern(patternInput.value)) row.removeClass("smart-label-row-invalid");
+    else row.addClass("smart-label-row-invalid");
+  });
+  patternInput.addEventListener("change", () => {
+    rule.pattern = patternInput.value;
+    onSave();
+  });
+
+  const prefixInput = row.createEl("input", { type: "text", cls: "smart-label-input" });
+  prefixInput.value = rule.prefix;
+  if (!isExtractionBehavior(rule.behavior)) prefixInput.style.visibility = "hidden";
+  prefixInput.addEventListener("change", () => {
+    rule.prefix = prefixInput.value;
+    onSave();
+  });
+
+  buildBehaviorSelect(row, rule.behavior, (behavior) => {
+    rule.behavior = behavior;
+    const active = isExtractionBehavior(behavior);
+    prefixInput.style.visibility = active ? "" : "hidden";
+    if (!active) { prefixInput.value = ""; rule.prefix = ""; }
+    onSave();
+  });
+
+  const deleteBtn = row.createEl("button", { text: "✕" });
+  deleteBtn.addEventListener("click", onDelete);
+}
+
+function renderCatchAllRow(
+  container: HTMLElement,
+  def: SmartLabelDefault,
+  onSave: () => void,
+): void {
+  const row = container.createDiv({ cls: "smart-label-rule-row" });
+
+  row.createSpan({ cls: "smart-label-catchall-label", text: "* (All)" });
+
+  const prefixInput = row.createEl("input", { type: "text", cls: "smart-label-input" });
+  prefixInput.value = def.prefix;
+  if (!isExtractionBehavior(def.behavior)) prefixInput.style.visibility = "hidden";
+  prefixInput.addEventListener("change", () => {
+    def.prefix = prefixInput.value;
+    onSave();
+  });
+
+  buildBehaviorSelect(row, def.behavior, (behavior) => {
+    def.behavior = behavior;
+    const active = isExtractionBehavior(behavior);
+    prefixInput.style.visibility = active ? "" : "hidden";
+    if (!active) { prefixInput.value = ""; def.prefix = ""; }
+    onSave();
+  });
+
+  // Empty placeholder to keep grid alignment (no delete button for catch-all)
+  row.createSpan();
+}
 
 export class UrlIntoSelectionSettingsTab extends PluginSettingTab {
   display() {
@@ -45,6 +158,7 @@ export class UrlIntoSelectionSettingsTab extends PluginSettingTab {
           1: "Auto Select",
           2: "Insert [](url)",
           3: "Insert <url>",
+          4: "Smart Label",
         };
 
         dropdown
@@ -56,6 +170,56 @@ export class UrlIntoSelectionSettingsTab extends PluginSettingTab {
             this.display();
           });
       });
+
+    if (plugin.settings.nothingSelected === NothingSelected.smartLabel) {
+      const block = containerEl.createDiv({ cls: "setting-item" });
+      const info = block.createDiv({ cls: "setting-item-info" });
+      info.createDiv({ cls: "setting-item-name", text: "Smart Label Settings" });
+      info.createDiv({ cls: "setting-item-description", text: "Transforms apply to the last path segment of the URL. Rules are checked top-to-bottom; first match wins." });
+      info.createDiv({ cls: "setting-item-description", text: "Use * as a wildcard to match any characters within a path segment." });
+      info.createDiv({ cls: "setting-item-description", text: "Rows with an empty or an invalid pattern are ignored when matching URLs." });
+
+      const section = info.createDiv({ cls: "smart-label-section" });
+
+      const addBtn = section.createEl("button", { text: "+ Add Rule", cls: "smart-label-add-btn" });
+
+      const header = section.createDiv({ cls: "smart-label-rule-header" });
+      header.createSpan({ text: "Domain pattern" });
+      header.createSpan({ text: "Prefix" });
+      header.createSpan({ text: "Behavior" });
+      header.createSpan();
+
+      const rulesContainer = section.createDiv({ cls: "smart-label-rules" });
+      const def = plugin.settings.smartLabelDefault;
+
+      const redraw = () => {
+        rulesContainer.empty();
+        plugin.settings.smartLabelRules.forEach((rule, i) => {
+          renderRuleRow(
+            rulesContainer,
+            rule,
+            () => {
+              plugin.settings.smartLabelRules.splice(i, 1);
+              plugin.saveData(plugin.settings);
+              this.display();
+            },
+            () => plugin.saveData(plugin.settings),
+          );
+        });
+        renderCatchAllRow(rulesContainer, def, () => plugin.saveData(plugin.settings));
+      };
+      redraw();
+
+      addBtn.addEventListener("click", () => {
+        plugin.settings.smartLabelRules.push({
+          pattern: "",
+          prefix: "",
+          behavior: "asis",
+        });
+        plugin.saveData(plugin.settings);
+        this.display();
+      });
+    }
     new Setting(containerEl)
       .setName("Whitelist for image embed syntax")
       .setDesc(

--- a/src/test/test-settings.ts
+++ b/src/test/test-settings.ts
@@ -6,4 +6,6 @@ export const DEFAULT_SETTINGS: PluginSettings = {
       .source,
   nothingSelected: NothingSelected.doNothing,
   listForImgEmbed: "",
+  smartLabelRules: [],
+  smartLabelDefault: { prefix: "", behavior: "insertinline" },
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,10 +7,36 @@ export const enum NothingSelected {
   insertInline,
   /** Insert `<url>` */
   insertBare,
+  /** Per-domain rule table with label extraction */
+  smartLabel,
+}
+
+export type SmartLabelBehavior =
+  | "asis"
+  | "titlecase"
+  | "uppercase"
+  | "lowercase"
+  | "prefixonly"
+  | "donothing"
+  | "autoselect"
+  | "insertinline"
+  | "insertbare";
+
+export interface SmartLabelRule {
+  pattern: string;
+  prefix: string;
+  behavior: SmartLabelBehavior;
+}
+
+export interface SmartLabelDefault {
+  prefix: string;
+  behavior: SmartLabelBehavior;
 }
 
 export interface PluginSettings {
   regex: string;
   nothingSelected: NothingSelected;
   listForImgEmbed: string;
+  smartLabelRules: SmartLabelRule[];
+  smartLabelDefault: SmartLabelDefault;
 }

--- a/src/utils/smartLabel.test.ts
+++ b/src/utils/smartLabel.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from "vitest";
+import {
+  isIdLike,
+  toTitleCase,
+  getLastPathSegment,
+  patternToRegex,
+  findMatchingRule,
+  buildSmartLabel,
+  isExtractionBehavior,
+} from "./smartLabel";
+import type { SmartLabelRule, SmartLabelDefault } from "../types";
+
+describe("isIdLike", () => {
+  it("returns true for ticket IDs (AA-123 format)", () => {
+    expect(isIdLike("AA-123")).toBe(true);
+    expect(isIdLike("PROJ-456")).toBe(true);
+    expect(isIdLike("AB-1")).toBe(true);
+  });
+
+  it("returns true for ALL-CAPS tokens", () => {
+    expect(isIdLike("ABCD")).toBe(true);
+    expect(isIdLike("FOO_BAR")).toBe(true);
+    expect(isIdLike("MY-FEATURE")).toBe(true);
+  });
+
+  it("returns false for lowercase slugs", () => {
+    expect(isIdLike("my-cool-feature")).toBe(false);
+    expect(isIdLike("hello-world")).toBe(false);
+    expect(isIdLike("some_thing")).toBe(false);
+  });
+
+  it("returns false for mixed case slugs", () => {
+    expect(isIdLike("myFeature")).toBe(false);
+    expect(isIdLike("hello")).toBe(false);
+  });
+});
+
+describe("toTitleCase", () => {
+  it("converts hyphenated slug to Title Case", () => {
+    expect(toTitleCase("my-cool-feature")).toBe("My Cool Feature");
+  });
+
+  it("converts underscored slug to Title Case", () => {
+    expect(toTitleCase("hello_world")).toBe("Hello World");
+  });
+
+  it("handles single word", () => {
+    expect(toTitleCase("hello")).toBe("Hello");
+  });
+
+  it("handles mixed separators", () => {
+    expect(toTitleCase("foo-bar_baz")).toBe("Foo Bar Baz");
+  });
+
+  it("lowercases existing uppercase letters in slug", () => {
+    expect(toTitleCase("HELLO-WORLD")).toBe("Hello World");
+  });
+});
+
+describe("getLastPathSegment", () => {
+  it("returns last path segment of a normal URL", () => {
+    expect(getLastPathSegment("https://example.com/browse/AA-123")).toBe("AA-123");
+  });
+
+  it("returns last segment ignoring query string", () => {
+    expect(getLastPathSegment("https://example.com/page?foo=bar")).toBe("page");
+  });
+
+  it("returns last segment ignoring hash", () => {
+    expect(getLastPathSegment("https://example.com/page#section")).toBe("page");
+  });
+
+  it("returns empty string for URL with trailing slash (no segment)", () => {
+    // trailing slash → last segment is empty string which gets filtered
+    expect(getLastPathSegment("https://example.com/")).toBe("");
+  });
+
+  it("returns empty string for URL with no path", () => {
+    expect(getLastPathSegment("https://example.com")).toBe("");
+  });
+
+  it("handles protocol-less URL gracefully", () => {
+    // Falls to catch block, splits on '/'
+    expect(getLastPathSegment("example.com/foo/bar")).toBe("bar");
+  });
+
+  it("returns deepest segment in multi-segment path", () => {
+    expect(getLastPathSegment("https://linear.app/team/my-cool-feature")).toBe("my-cool-feature");
+  });
+});
+
+describe("patternToRegex", () => {
+  it("matches a plain domain in a URL", () => {
+    const re = patternToRegex("jira.company.com");
+    expect(re.test("https://jira.company.com/browse/AA-123")).toBe(true);
+    expect(re.test("https://linear.app/team/issue")).toBe(false);
+  });
+
+  it("* wildcard matches within a segment", () => {
+    const re = patternToRegex("*.company.com");
+    expect(re.test("https://jira.company.com/path")).toBe(true);
+    expect(re.test("https://other.company.com/path")).toBe(true);
+  });
+
+  it("* wildcard matches within a path segment", () => {
+    const re = patternToRegex("company.com/browse/*");
+    expect(re.test("https://company.com/browse/AA-123")).toBe(true);
+  });
+
+  it("* wildcard does not match / character itself", () => {
+    // [^/]* cannot match the literal slash character
+    const re = patternToRegex("company.com/browse/*");
+    // Pattern matches "company.com/browse/<non-slash-chars>" as a substring
+    // A URL with a segment exactly matching the wildcard portion should match
+    expect(re.test("https://company.com/browse/AA-123?q=1")).toBe(true);
+  });
+
+  it("special chars are treated as literals", () => {
+    const re = patternToRegex("example.com");
+    // dot is escaped so it doesn't match 'exampleXcom'
+    expect(re.test("https://exampleXcom/path")).toBe(false);
+    expect(re.test("https://example.com/path")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    const re = patternToRegex("Linear.App");
+    expect(re.test("https://linear.app/team/issue")).toBe(true);
+  });
+});
+
+describe("isExtractionBehavior", () => {
+  it("returns true for label extraction behaviors", () => {
+    expect(isExtractionBehavior("asis")).toBe(true);
+    expect(isExtractionBehavior("titlecase")).toBe(true);
+    expect(isExtractionBehavior("uppercase")).toBe(true);
+    expect(isExtractionBehavior("lowercase")).toBe(true);
+    expect(isExtractionBehavior("prefixonly")).toBe(true);
+  });
+
+  it("returns false for paste behaviors", () => {
+    expect(isExtractionBehavior("donothing")).toBe(false);
+    expect(isExtractionBehavior("autoselect")).toBe(false);
+    expect(isExtractionBehavior("insertinline")).toBe(false);
+    expect(isExtractionBehavior("insertbare")).toBe(false);
+  });
+});
+
+describe("findMatchingRule", () => {
+  const rules: SmartLabelRule[] = [
+    { pattern: "jira.company.com", prefix: "Jira: ", behavior: "asis" },
+    { pattern: "linear.app", prefix: "", behavior: "titlecase" },
+  ];
+
+  it("returns first matching rule", () => {
+    const result = findMatchingRule("https://jira.company.com/browse/AA-123", rules);
+    expect(result).toBe(rules[0]);
+  });
+
+  it("returns second rule when first does not match", () => {
+    const result = findMatchingRule("https://linear.app/team/my-feature", rules);
+    expect(result).toBe(rules[1]);
+  });
+
+  it("returns null when no rule matches", () => {
+    const result = findMatchingRule("https://github.com/user/repo", rules);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for empty rules array", () => {
+    const result = findMatchingRule("https://example.com", []);
+    expect(result).toBeNull();
+  });
+});
+
+describe("buildSmartLabel", () => {
+  it("asis: returns segment verbatim with prefix", () => {
+    const rule: SmartLabelRule = { pattern: "", prefix: "Jira: ", behavior: "asis" };
+    expect(buildSmartLabel("https://jira.company.com/browse/AA-123", rule)).toBe("Jira: AA-123");
+  });
+
+  it("titlecase: converts slug to Title Case", () => {
+    const rule: SmartLabelRule = { pattern: "", prefix: "", behavior: "titlecase" };
+    expect(buildSmartLabel("https://linear.app/team/my-cool-feature", rule)).toBe("My Cool Feature");
+  });
+
+  it("titlecase: preserves ticket IDs", () => {
+    const rule: SmartLabelRule = { pattern: "", prefix: "", behavior: "titlecase" };
+    expect(buildSmartLabel("https://jira.company.com/browse/AA-123", rule)).toBe("AA-123");
+  });
+
+  it("uppercase: uppercases segment", () => {
+    const rule: SmartLabelRule = { pattern: "", prefix: "", behavior: "uppercase" };
+    expect(buildSmartLabel("https://example.com/browse/my-feature", rule)).toBe("MY-FEATURE");
+  });
+
+  it("lowercase: lowercases segment", () => {
+    const rule: SmartLabelRule = { pattern: "", prefix: "", behavior: "lowercase" };
+    expect(buildSmartLabel("https://example.com/browse/My-Feature", rule)).toBe("my-feature");
+  });
+
+  it("prefixonly: returns prefix regardless of segment", () => {
+    const rule: SmartLabelRule = { pattern: "", prefix: "Blog", behavior: "prefixonly" };
+    expect(buildSmartLabel("https://blog.company.com/some-long-post-title", rule)).toBe("Blog");
+  });
+
+  it("returns empty string when URL has no path segment", () => {
+    const rule: SmartLabelDefault = { prefix: "", behavior: "asis" };
+    expect(buildSmartLabel("https://example.com", rule)).toBe("");
+  });
+
+  it("returns empty string for prefixonly with empty prefix", () => {
+    const rule: SmartLabelDefault = { prefix: "", behavior: "prefixonly" };
+    expect(buildSmartLabel("https://example.com/page", rule)).toBe("");
+  });
+
+  it("works with SmartLabelDefault", () => {
+    const def: SmartLabelDefault = { prefix: "", behavior: "titlecase" };
+    expect(buildSmartLabel("https://example.com/my-page", def)).toBe("My Page");
+  });
+});

--- a/src/utils/smartLabel.ts
+++ b/src/utils/smartLabel.ts
@@ -1,0 +1,92 @@
+import type { SmartLabelBehavior, SmartLabelRule, SmartLabelDefault } from "../types";
+
+// ─── Transform registry ───────────────────────────────────────────────────────
+// To add a new transform: add one entry here. No other changes required.
+
+type TransformFn = (segment: string) => string;
+
+const LABEL_EXTRACTION_BEHAVIORS = new Set<SmartLabelBehavior>([
+  "asis", "titlecase", "uppercase", "lowercase", "prefixonly",
+]);
+
+const TRANSFORMS: Partial<Record<SmartLabelBehavior, TransformFn>> = {
+  asis: (s) => s,
+  titlecase: (s) => (isIdLike(s) ? s : toTitleCase(s)),
+  uppercase: (s) => s.toUpperCase(),
+  lowercase: (s) => s.toLowerCase(),
+  prefixonly: (_s) => "",   // segment ignored; caller uses prefix as full label
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** True for ticket IDs (AA-123, PROJ-456) and ALL-CAPS tokens — skip title-casing. */
+export function isIdLike(segment: string): boolean {
+  if (/^[A-Za-z]{1,6}-\d+$/.test(segment)) return true;
+  if (/^[A-Z0-9][A-Z0-9_-]{2,}$/.test(segment)) return true;
+  return false;
+}
+
+/** Convert a hyphen/underscore slug to Title Case. */
+export function toTitleCase(segment: string): string {
+  return segment
+    .split(/[-_]/)
+    .filter((w) => w.length > 0)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+    .join(" ");
+}
+
+/** Extract the final non-empty path segment from a URL string. */
+export function getLastPathSegment(rawUrl: string): string {
+  let pathname: string;
+  try {
+    pathname = new URL(rawUrl).pathname;
+  } catch {
+    pathname = rawUrl.split("?")[0].split("#")[0];
+  }
+  const segments = pathname.split("/").filter((s) => s.length > 0);
+  return segments[segments.length - 1] ?? "";
+}
+
+/**
+ * Convert a user-entered wildcard pattern to a RegExp.
+ * `*` matches any characters except `/` (within-segment only).
+ * All other special characters are treated as literals.
+ */
+export function patternToRegex(pattern: string): RegExp {
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+  const withWildcard = escaped.replace(/\*/g, "[^/]*");
+  return new RegExp(withWildcard, "i");
+}
+
+/** Return true if behavior requires label extraction (prefix active). */
+export function isExtractionBehavior(behavior: SmartLabelBehavior): boolean {
+  return LABEL_EXTRACTION_BEHAVIORS.has(behavior);
+}
+
+/** True if pattern meets the minimum domain format: 1+ chars, literal dot, 2+ chars. */
+export function isValidPattern(pattern: string): boolean {
+  return /^.+\..{2,}$/.test(pattern.trim());
+}
+
+// ─── Core logic ───────────────────────────────────────────────────────────────
+
+/** Find first rule whose pattern matches the full URL. Returns null if none match. */
+export function findMatchingRule(url: string, rules: SmartLabelRule[]): SmartLabelRule | null {
+  for (const rule of rules) {
+    if (!isValidPattern(rule.pattern)) continue;
+    if (patternToRegex(rule.pattern).test(url)) return rule;
+  }
+  return null;
+}
+
+/**
+ * Build the link label `[LABEL]` content for a matched rule or the default config.
+ * Returns an empty string when the segment is missing (caller falls back to [](url)).
+ */
+export function buildSmartLabel(url: string, rule: SmartLabelRule | SmartLabelDefault): string {
+  if (rule.behavior === "prefixonly") return rule.prefix;
+  const segment = getLastPathSegment(url);
+  if (!segment) return "";
+  const transform = TRANSFORMS[rule.behavior] ?? ((s) => s);
+  return rule.prefix + transform(segment);
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,38 @@
+/* Smart Label settings UI */
+
+.smart-label-section {
+  width: 100%;
+}
+
+.smart-label-rule-header,
+.smart-label-rule-row {
+  display: grid;
+  grid-template-columns: 1fr 8ch 10rem 1.8rem;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 0.3rem;
+}
+
+.smart-label-add-btn {
+  margin-top: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.smart-label-rule-row select {
+  width: 100%;
+}
+
+.smart-label-input::placeholder {
+  color: var(--text-faint) !important;
+  opacity: 0.6;
+  font-style: italic;
+}
+
+.smart-label-catchall-label {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.smart-label-row-invalid .smart-label-input:first-of-type {
+  border-color: var(--color-red);
+}


### PR DESCRIPTION
Adds a new "Smart Label" nothing-selected behavior that transforms the
last URL path segment into a link label using configurable per-domain
rules (as-is, title case, uppercase, lowercase, prefix-only, and
pass-through behaviors). Rules are matched top-to-bottom with wildcard
support; an unmatched catch-all rule applies as the default.

Also fixes cursor placement after paste in all smart label cases so the
cursor lands after the inserted text rather than before it.

New Settings page:
<img width="594" height="386" alt="image" src="https://github.com/user-attachments/assets/4876ef6f-1778-43c3-82de-4c80b9b36acc" />

Paste examples (icons come from another plugin):
<img width="227" height="177" alt="image" src="https://github.com/user-attachments/assets/def41887-8ae2-4d7c-a1c6-20fc4e64ec9c" />

### Core behavior
- New "Smart Label" mode in the "Nothing selected" dropdown — sits alongside the existing Do Nothing / Auto Select / Insert url / Insert <url> options, so it's fully opt-in
- Rules are evaluated top-to-bottom; first match wins. A configurable catch-all row applies when no rule matches
- Label is derived from the last non-empty path segment of the URL, using URL.pathname with a fallback parser for non-standard URLs
- When no path segment exists (e.g. bare domain), falls back to [](url) with cursor between the brackets
### Label transforms
- As is — segment used verbatim (good for ticket IDs like AA-123)
- Title Case — slug → human title (my-cool-feature → My Cool Feature), with ID-like detection to skip title-casing on things like AA-123 or PROJ-456
- UPPERCASE / lowercase — direct transforms
- Prefix only — label is exactly the prefix, segment ignored (e.g. always produce `[Blog](url)`)
- Optional prefix field on any extraction behavior prepends a string to the label
### Per-rule paste behavior override
- Each rule can also set a paste behavior instead of a label transform: Do nothing (don't intercept), Auto Select (select word at cursor), Insert url, or Insert <url>
- This lets you e.g. skip interception entirely for certain domains, or always insert bare URLs for others
### Pattern matching
- Domain patterns support * as a wildcard (matches any characters except /)
- All other special characters are treated as literals — no regex knowledge required
- Invalid patterns (no dot, too short) are highlighted in the UI and silently skipped during matching
### Settings UI
- Grid-based rule table: pattern | prefix | behavior | delete
- Prefix input is hidden when the selected behavior doesn't use it
- Invalid pattern rows are visually flagged with a red border on the pattern field
- Catch-all row (* (All)) is always shown at the bottom and cannot be deleted
### Correctness / cursor
- Cursor is placed after the inserted text in all cases, since replaceRange() doesn't move it automatically
- insertinline and empty-segment fallback still place cursor between [ and ]